### PR TITLE
fix: typo in config file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Status information about local or remote Syncthing instances
 
-- Place your config in `~/.config/syncthing_status/devices.yaml`
+- Place your config in `~/.config/syncthing_status/devices.yml`
 - Your can retrieve your `api_key` from the web panel of your Syncthing instance
 - This is designed to be used in your status bar (Polybar, etc.)
 


### PR DESCRIPTION
Debugging my error was quite frustrating as the path in the README is wrong. :(